### PR TITLE
chore(workflow): remove tag triggers from deployment (development)

### DIFF
--- a/.github/workflows/maven-central.yml
+++ b/.github/workflows/maven-central.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
 
 jobs:
   deploy:


### PR DESCRIPTION
- Removed tag-based triggers from the Maven Central deployment workflow.
- Deployment will now only be triggered on pushes to the main branch.