### PR TITLE
```plaintext

### DIFF
--- a/.github/workflows/maven-central.yml
+++ b/.github/workflows/maven-central.yml
@@ -24,5 +24,21 @@ jobs:
       - name: Build and deploy to Maven Central
         run: |
           mkdir -p ~/.m2
-          echo "<settings><servers><server><id>gpg.passphrase</id><passphrase>${{ secrets.GPG_PASSPHRASE }}</passphrase></server></servers></settings>" > ~/.m2/settings.xml
+          cat > ~/.m2/settings.xml <<EOF
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <servers>
+              <server>
+                <id>ossrh</id>
+                <username>${{ secrets.OSSRH_USERNAME }}</username>
+                <password>${{ secrets.OSSRH_PASSWORD }}</password>
+              </server>
+              <server>
+                <id>gpg.passphrase</id>
+                <passphrase>${{ secrets.GPG_PASSPHRASE }}</passphrase>
+              </server>
+            </servers>
+          </settings>
+          EOF
           mvn clean deploy -P release --batch-mode --no-transfer-progress

--- a/src/main/java/xyz/quartzframework/core/bean/registry/DefaultPluginBeanDefinitionRegistry.java
+++ b/src/main/java/xyz/quartzframework/core/bean/registry/DefaultPluginBeanDefinitionRegistry.java
@@ -297,9 +297,12 @@ public class DefaultPluginBeanDefinitionRegistry implements PluginBeanDefinition
                 .literalType(clazz)
                 .resolvableType(ResolvableType.forClass(clazz))
                 .instance(instance)
+                .listenMethods(mapListenMethods(clazz).getOrDefault(Listen.class, Collections.emptyList()))
+                .lifecycleMethods(mapLifecycleMethods(clazz))
                 .injected(true)
                 .build();
         registerBeanDefinition(definition.getName(), definition);
+        defineProvideMethods(clazz, definition.isProxied());
     }
 
     @Override


### PR DESCRIPTION
chore: update Maven Central workflow and bean registry (development)

- Updated Maven Central deployment workflow:
  - Removed tag-based triggers.
  - Deployment now triggers on pushes to the main branch.
- Enhanced DefaultPluginBeanDefinitionRegistry:
  - Added listen and lifecycle methods mapping.
  - Integrated provide methods definition.
```