### PR TITLE
```plaintext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,28 +185,6 @@
                 <version>2.22.2</version>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <gpgArguments>
-                        <arg>--pinentry-mode</arg>
-                        <arg>loopback</arg>
-                    </gpgArguments>
-                    <useAgent>false</useAgent>
-                    <passphraseServerId>gpg.passphrase</passphraseServerId>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <version>1.6.13</version>


### PR DESCRIPTION
chore: remove maven-gpg-plugin from pom.xml (development)

- Eliminated the maven-gpg-plugin configuration to streamline the build process.
- Removed associated executions and configurations:
  - Signing artifacts in the 'verify' phase.
  - GPG arguments and passphrase management.
- This change simplifies the Maven setup and reduces complexity in the build pipeline.
```