### PR TITLE
fix(pom.xml): update MIT license URL to use HTTPS (main)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <url>https://www.opensource.org/licenses/mit-license.php</url>
         </license>
     </licenses>
 


### PR DESCRIPTION
Change the MIT license URL in pom.xml from HTTP to HTTPS for enhanced security and to avoid potential mixed content issues.